### PR TITLE
fix(Create.jsx, MyProfile.jsx): update Cloudinary upload preset and API URL

### DIFF
--- a/src/views/Create.jsx
+++ b/src/views/Create.jsx
@@ -26,9 +26,9 @@ function Create() {
 			const data = new FormData();
 			if (image) {
 				data.append('file', image);
-				data.append('upload_preset', 'purchaseApp');
+				data.append('upload_preset', 'social_media_app');
 				const response = await axios.post(
-					'https://api.cloudinary.com/v1_1/yilin1234/image/upload',
+					'https://api.cloudinary.com/v1_1/da4jbx5r9/image/upload',
 					data
 				);
 				return response.data.secure_url;

--- a/src/views/MyProfile.jsx
+++ b/src/views/MyProfile.jsx
@@ -30,9 +30,9 @@ function MyProfile() {
 			const data = new FormData();
 			if (image) {
 				data.append('file', image);
-				data.append('upload_preset', 'purchaseApp');
+				data.append('upload_preset', 'social_media_app');
 				const response = await axios.post(
-					'https://api.cloudinary.com/v1_1/yilin1234/image/upload',
+					'https://api.cloudinary.com/v1_1/da4jbx5r9/image/upload',
 					data
 				);
 				return response.data.secure_url;


### PR DESCRIPTION


The Cloudinary upload preset has been changed from 'purchaseApp' to 'social_media_app' in both the Create and MyProfile components. Additionally, the API URL for Cloudinary has been updated from 'https://api.cloudinary.com/v1_1/yilin1234/image/upload' to 'https://api.cloudinary.com/v1_1/da4jbx5r9/image/upload'. These changes ensure that the correct upload preset and API URL are used for uploading images to Cloudinary.