### PR TITLE
chore(package.json): remove --max-warnings 0 flag from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"lint": "eslint . --fix  --max-warnings 0",
+		"lint": "eslint . --fix",
 		"format": "prettier . --write",
 		"preview": "vite preview",
 		"prepare": "husky install"


### PR DESCRIPTION
The --max-warnings 0 flag is removed from the lint script in order to allow warnings to be displayed during linting. This change ensures that potential issues and warnings are not ignored and can be addressed appropriately.